### PR TITLE
chore: bump nextcloud/ocp to dev-stable32 (NSW-946)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"php": "^8.1"
 	},
 	"require-dev": {
-		"nextcloud/ocp": "dev-stable31",
+		"nextcloud/ocp": "dev-stable32",
 		"roave/security-advisories": "dev-latest"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fa95966784100e6ba07bc75bffbd527",
+    "content-hash": "dec62b8fb6680420bfa11f20bbf40349",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -67,16 +67,16 @@
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "dev-stable31",
+            "version": "dev-stable32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "abd32429d794ede1d92b7b0a88a1070371c907b5"
+                "reference": "69c9d06aa3e899dfb74d6c035951dbc7613f2649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/abd32429d794ede1d92b7b0a88a1070371c907b5",
-                "reference": "abd32429d794ede1d92b7b0a88a1070371c907b5",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/69c9d06aa3e899dfb74d6c035951dbc7613f2649",
+                "reference": "69c9d06aa3e899dfb74d6c035951dbc7613f2649",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-stable31": "31.0.0-dev"
+                    "dev-stable32": "32.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -109,9 +109,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2025-07-31T00:57:37+00:00"
+            "time": "2026-08-07T02:03:41+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
## Summary

- Bump `nextcloud/ocp` from `dev-stable31` to `dev-stable32` in `composer.json` + `composer.lock`

No `appinfo/info.xml` change: the app already declares `min-version="31" max-version="32"`.

## Why

Part of the NC32 sweep over IONOS-owned apps. This app was **already NC32-compatible** — CI
Psalms it against stable32 today, because `psalm-matrix.yml` derives its matrix from `info.xml`
via `nextcloud-version-matrix` and then does `composer require --dev nextcloud/ocp:${{ matrix.ocp-version }}`.
The `composer.json` pin only affects local runs, where `composer psalm` was checking against
NC31 stubs. This aligns it.

## Audit (NC32 removed APIs)

- `OC_Helper::` — none ✅
- `OC_Template` / `OCP\Template` / `OC_Util::add*` — none ✅
- `appinfo/app.php` — absent ✅
- `/apps/files/api/v1/thumbnail` — none ✅

`php: ^8.1` and `config.platform.php: 8.1` deliberately unchanged — the app still declares
`min-version="31"`, and the constraint tracks the *lowest* supported NC.

Jira: NSW-946